### PR TITLE
Fix setup.py and add MANIFEST.in to make it installable from pypi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst


### PR DESCRIPTION
The setup.py file tries to open README.rst during any operation, which
fails, as that file is not included in the source distribution. It's
especially bad, since nothing is then done with the data that is read
from that file.

This patch removes the reading of README.rst from setup.py, adds a
MANIFEST.in file to properly include README.rst in the source
distribution, and cleans up the setup.py file a little bit.
