### PR TITLE
Fix setup.py and add MANIFEST.in to make it installable from pypi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,10 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-long_description = open('README.rst').read()
 
 setup(
     name='django-xstatic',
     version='0.0.1',
-    description='Django helpers to use xstatic packages in django projects',
-    long_description="",
+    description='Django helpers to use XStatic packages in Django projects',
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Development Status :: 3 - Alpha',
@@ -18,13 +16,11 @@ setup(
         'Topic :: System :: Installation/Setup',
         'Topic :: System :: Software Distribution',
         ],
-    keywords="",
     author='Gautier Hayoun',
     author_email='ghayoun@gmail.com',
     url='http://github.com/gautier/django-xstatic',
     license='MIT license',
-    packages=find_packages(),
+    packages=['django_xstatic'],
     install_requires=[''], # yeah, not even XStatic, isn't that MAGIC?
                            # No, it's just smart convention
 )
-


### PR DESCRIPTION
The setup.py file tries to open README.rst during any operation, which
fails, as that file is not included in the source distribution. It's
especially bad, since nothing is then done with the data that is read
from that file.

This patch removes the reading of README.rst from setup.py, adds a
MANIFEST.in file to properly include README.rst in the source
distribution, and cleans up the setup.py file a little bit.
